### PR TITLE
Fix scoping mismatch for start routine in clisp

### DIFF
--- a/src/clisp.lisp
+++ b/src/clisp.lisp
@@ -27,19 +27,19 @@
   (when error
     (warn "Can not control EXTERNAL-PROGRAM:RUN error output in CLISP."))
   (multiple-value-bind (primary-stream input-stream output-stream)
-      (ext:run-program program :arguments args
-                       :input (if (eq input t) :terminal input)
-                       :output (if (eq output t) :terminal output)
-                       :if-output-exists if-output-exists
-                       :wait nil))
-  (cond ((and (eq input :stream) (eq output :stream))
-         (close primary-stream)
-         (make-external-process :in-stream input-stream
-                                :out-stream output-stream))
-        ((eq input :stream)
-         (make-external-process :in-stream primary-stream))
-        ((eq output :stream)
-         (make-external-process :out-stream primary-stream))))
+    (ext:run-program program :arguments args
+                     :input (if (eq input t) :terminal input)
+                     :output (if (eq output t) :terminal output)
+                     :if-output-exists if-output-exists
+                     :wait nil)
+    (cond ((and (eq input :stream) (eq output :stream))
+           (close primary-stream)
+           (make-external-process :in-stream input-stream
+                                  :out-stream output-stream))
+          ((eq input :stream)
+           (make-external-process :in-stream primary-stream))
+          ((eq output :stream)
+           (make-external-process :out-stream primary-stream)))))
 
 (defmethod process-input-stream (process)
   (external-process-in-stream process))


### PR DESCRIPTION
A (multiple-value-bind ..) form was closed too soon, causing an error
when the subsequent form referenced variables from that bind.
