### PR TITLE
Improve input/output stream handling for CLISP

### DIFF
--- a/src/clisp.lisp
+++ b/src/clisp.lisp
@@ -30,7 +30,7 @@
     (error "CLISP does not support supplying streams for input or output."))
   (when error
     (warn "Can not control EXTERNAL-PROGRAM:RUN error output in CLISP."))
-  (multiple-value-bind (primary-stream input-stream output-stream)
+  (multiple-value-bind (primary-stream output-stream input-stream)
     (ext:run-program program :arguments args
                      :input (if (eq input t) :terminal input)
                      :output (if (eq output t) :terminal output)


### PR DESCRIPTION
When neither of both keyword arguments was supplied to (start) it would
fail to return the started process. This is now fixed.

CLISP also does not support binding the stdin/stdout of the new process
to existing streams (as e.g. SBCL does). This is part of the general
API, so an explicit check is added to (run) and (start) that raises an
error if custom streams are supplied under CLISP. This breaks the API,
but an error was being generated anyway (by CLISP), this just makes it
clearer why it does not work.
