### PR TITLE
Accept numeric signals on SBCL.

### DIFF
--- a/src/sbcl.lisp
+++ b/src/sbcl.lisp
@@ -40,8 +40,14 @@
          "/usr/bin/env" (stringify-args (cons program args)) :search t :wait nil
          (convert-environment rest environment replace-environment-p)))
 
-(defmethod signal-process (process signal)
-  (sb-ext:process-kill process (cdr (assoc signal *signal-mapping*))))
+(defmethod signal-process (process (signal symbol))
+  (let ((sig (assoc signal *signal-mapping*)))
+    (if (not sig)
+        (error "Symbolic signal ~A not supported." signal)
+        (signal-process process (cdr sig)))))
+
+(defmethod signal-process (process (signal integer))
+  (sb-ext:process-kill process signal))
 
 (defmethod process-input-stream (process)
   (sb-ext:process-input process))


### PR DESCRIPTION
Mismatch between SIGNAL-PROCESS documentation and SBCL implementation. Modified SBCL implementation to allow numeric signals to be sent.
