### PR TITLE
Fix load failure on Allegro 9.0.

### DIFF
--- a/src/allegro.lisp
+++ b/src/allegro.lisp
@@ -8,7 +8,6 @@
 ;;;; Documentation at http://www.franz.com/support/documentation/6.2/doc/os-interface.htm#subprocess-functions-1
 
 (eval-when (:compile-toplevel :load-toplevel :execute)
-  (require :system)
   (require :osi))
 
 (defmethod run


### PR DESCRIPTION
On 9.0, (require :system) attempts to load a patch which cannot be loaded that way. Franz has informed me that (require :system) is needless here.