### PR TITLE
can't load system package after compile on windows

### DIFF
--- a/src/allegro.lisp
+++ b/src/allegro.lisp
@@ -8,7 +8,7 @@
 ;;;; Documentation at http://www.franz.com/support/documentation/6.2/doc/os-interface.htm#subprocess-functions-1
 
 (eval-when (:compile-toplevel :load-toplevel :execute)
-  (require :system)
+  #-os-windows (require :system)
   (require :osi))
 
 (defmethod run


### PR DESCRIPTION
Hi I couldn't #'ql:quickload external program on windows allegro.  This works for me!