### PR TITLE
Some small corrections for Lispworks.

### DIFF
--- a/src/lispworks.lisp
+++ b/src/lispworks.lisp
@@ -72,7 +72,6 @@
                                    (external-process-error-stream
                                     process))
                                :wait nil)))
-    (format *debug-io* "Exit code: ~a~%" status-code)
     (values (if status-code :exited :running) status-code)))
 
 (defmethod process-p ((process external-process))

--- a/tests/tests.lisp
+++ b/tests/tests.lisp
@@ -62,3 +62,11 @@
       (external-program:run "ls" '(".") :replace-environment-p t)
     (is (eq :exited status))
     (is (/= 0 code))))
+
+(test run-async
+  (let ((process (external-program:start "sleep" '("3"))))
+    (let ((status-1 (external-program:process-status process)))
+      (is (eq :running status-1))
+      (sleep 5)
+      (let ((status-2 (external-program:process-status process)))
+        (is (eq :exited status-2))))))


### PR DESCRIPTION
Corrected use of :wait t/nil in external-program:run/external-program:start.

Make external-program:process-status use sys:pipe-exit-status instead of
sys.pid-exit-status for Lispworks 7.
Added external-program-tests:run-async.