### PR TITLE
ecl: Implement process-id and process-status

### DIFF
--- a/src/ecl.lisp
+++ b/src/ecl.lisp
@@ -3,13 +3,14 @@
 
 (in-package :external-program)
 
-;;; Outdated docs in http://ecls.sourceforge.net/new-manual/re11.html, but code
-;;; is in ecl/src/c/unixsys.d
+;;; Docs in https://common-lisp.net/project/ecl/manual/rn01.html
+;;; Code is in ecl/src/c/unixsys.d
 
 (defstruct external-process
   inputp
   outputp
-  stream)
+  stream
+  process)
 
 (defmethod run
     (program args
@@ -36,14 +37,16 @@
       (error "ECL can not create a stream for error output."))
   (multiple-value-bind (program args)
       (embed-environment program args environment replace-environment-p)
-    (make-external-process :inputp (eq input :stream)
-                           :outputp (eq output :stream)
-                           :stream (ext:run-program program
-                                                    (stringify-args args)
-                                                    :wait nil
-                                                    :input input
-                                                    :output output
-                                                    :error error))))
+      (multiple-value-bind (stream return-value process)
+                           (ext:run-program program (stringify-args args)
+                                            :wait nil
+                                            :input input
+                                            :output output
+                                            :error error)
+                           (make-external-process :inputp (eq input :stream)
+                                                  :outputp (eq output :stream)
+                                                  :stream stream
+                                                  :process process))))
 
 (defmethod process-input-stream ((process external-process))
   (if (external-process-inputp process)
@@ -57,6 +60,12 @@
   (declare (ignore process))
   nil)
 
+(defmethod process-id ((process external-process))
+  (ext:external-process-pid (external-process-process process)))
+
 (defmethod process-p ((process external-process))
   (declare (ignore process))
   t)
+
+(defmethod process-status ((process external-process))
+  (ext:external-process-status (external-process-process process)))


### PR DESCRIPTION
`ext:run-program` returns a structure that is documented [here](https://common-lisp.net/project/ecl/manual/rn01re63.html). We can access the slot for the PID; for the process status, there's also a function.