### PR TITLE
mkcl: Initial support

### DIFF
--- a/external-program.asd
+++ b/external-program.asd
@@ -22,11 +22,12 @@
                       ;; #+liquid "liquid"
                       #+lispworks "lispworks"
                       ;; #+lucid "lucid"
+                      #+mkcl "mkcl"
                       #+openmcl "openmcl"
                       #+sbcl "sbcl"
                       ;; #+scl "scieneer"
-                      #-(or allegro armedbear clisp cmu ecl lispworks openmcl
-                            sbcl)
+                      #-(or allegro armedbear clisp cmu ecl lispworks mkcl
+                            openmcl sbcl)
                       "unsupported"
                       :depends-on ("utilities")))
   :in-order-to ((test-op (load-op external-program-test)))

--- a/src/mkcl.lisp
+++ b/src/mkcl.lisp
@@ -68,3 +68,6 @@
 
 (defmethod process-status ((process external-process))
   (mk-ext:process-status (external-process-process process)))
+
+(defmethod wait-for-process ((process external-process))
+  (mk-ext:join-process (external-process-process process)))

--- a/src/mkcl.lisp
+++ b/src/mkcl.lisp
@@ -1,0 +1,70 @@
+;;; Copyright 2006, 2007 Greg Pfeil
+;;; Distributed under the LLGPL (see LICENSE file)
+
+(in-package :external-program)
+
+;;; Code is in mkcl/src/c/unixsys.d
+
+(defstruct external-process
+  inputp
+  outputp
+  stream
+  process)
+
+(defmethod run
+    (program args
+     &key input output error environment replace-environment-p
+     &allow-other-keys)
+  (if (or output error)
+      (warn "Can not control EXTERNAL-PROGRAM:RUN output in MKCL."))
+  (if input (error "Can not send input to EXTERNAL-PROGRAM:RUN in MKCL."))
+  (multiple-value-bind (program args)
+      (embed-environment program args environment replace-environment-p)
+    (values :exited
+            (nth-value 2
+                       (mk-ext:run-program program (stringify-args args)
+                                           :wait t
+                                           :input input
+                                           :output output
+                                           :error error)))))
+
+(defmethod start
+    (program args
+     &key input output error environment replace-environment-p
+     &allow-other-keys)
+  (if (eq error :stream)
+      (error "MKCL can not create a stream for error output."))
+  (multiple-value-bind (program args)
+      (embed-environment program args environment replace-environment-p)
+      (multiple-value-bind (stream process return-value)
+                           (mk-ext:run-program program (stringify-args args)
+                                               :wait nil
+                                               :input input
+                                               :output output
+                                               :error error)
+                           (make-external-process :inputp (eq input :stream)
+                                                  :outputp (eq output :stream)
+                                                  :stream stream
+                                                  :process process))))
+  
+(defmethod process-input-stream ((process external-process))
+  (if (external-process-inputp process)
+      (external-process-stream process)))
+
+(defmethod process-output-stream ((process external-process))
+  (if (external-process-outputp process)
+      (external-process-stream process)))
+
+(defmethod process-error-stream ((process external-process))
+  (declare (ignore process))
+  nil)
+
+(defmethod process-p ((process external-process))
+  (declare (ignore process))
+  t)
+
+(defmethod process-id ((process external-process))
+  (mk-ext:process-id (external-process-process process)))
+
+(defmethod process-status ((process external-process))
+  (mk-ext:process-status (external-process-process process)))


### PR DESCRIPTION
This is essentially a copy&paste from ecl. Main differences:
 - namespace `mk-ext` instead of `ext`

In addition to that, the following differences might be of interest in the future:
 - Even though `mkcl` has no general function to send signals, the special case of process termination is handled through `mk-ext:terminate-process`.