### PR TITLE
Add wait-for-process

### DIFF
--- a/src/cmucl.lisp
+++ b/src/cmucl.lisp
@@ -50,3 +50,6 @@
 
 (defmethod process-p (process)
   (ext:process-p process))
+
+(defmethod wait-for-process (process)
+  (ext:process-wait process))

--- a/src/ecl.lisp
+++ b/src/ecl.lisp
@@ -60,3 +60,6 @@
 (defmethod process-p ((process external-process))
   (declare (ignore process))
   t)
+
+(defmethod wait-for-process ((process external-process))
+  (ext:external-process-wait (external-process-process process) t))

--- a/src/external-program.lisp
+++ b/src/external-program.lisp
@@ -6,7 +6,7 @@
   (:export #:start #:run #:signal-process
 	   #:process-id #:process-input-stream
 	   #:process-output-stream #:process-error-stream
-	   #:process-status #:process-p)
+	   #:process-status #:process-p #:wait-for-process)
   (:documentation ""))
 
 (in-package :external-program)
@@ -146,6 +146,14 @@ the process changes. The function takes the process as an argument.")
   (:method (process)
     (declare (ignore process))
     nil))
+
+(defgeneric wait-for-process (process)
+  (:documentation "Wait for asynchronously launched process to exit.")
+  (:method (process)
+    (if (process-p process)
+        (error "This CL implementation does not support WAIT-FOR-PROCESS.")
+        (error "Incorrect argument type (~a) for WAIT-FOR-PROCESS."
+               (type-of process)))))
 
 (defvar *signal-mapping*
   '((:hangup . 1)

--- a/src/openmcl.lisp
+++ b/src/openmcl.lisp
@@ -49,3 +49,6 @@
 
 (defmethod process-p ((process ccl:external-process))
   t)
+
+(defmethod wait-for-process (process)
+  (ccl::external-process-wait process))

--- a/src/sbcl.lisp
+++ b/src/sbcl.lisp
@@ -81,3 +81,6 @@
 
 (defmethod process-p (process)
   (sb-ext:process-p process))
+
+(defmethod wait-for-process (process)
+  (sb-ext:process-wait process))

--- a/tests/tests.lisp
+++ b/tests/tests.lisp
@@ -70,3 +70,9 @@
       (sleep 5)
       (let ((status-2 (external-program:process-status process)))
         (is (eq :exited status-2))))))
+
+(test wait-for-async
+  (let ((process (external-program:start "sleep" '("3"))))
+    (external-program:wait-for-process process)
+    (let ((status (external-program:process-status process)))
+      (is (eq :exited status)))))


### PR DESCRIPTION
This addresses the feature request from issue #30.

The good:
 * I've successfully tested this with sbcl and ccl.

The bad:
 * I could not test with cmucl because of issue #12.
 * The function provided by ecl for this purpose appears to be broken (I chose to make this explicit by not overriding the dummy from external-program.lisp in ecl.lisp).