### PR TITLE
Remove spurious quoting of environment values (SBCL)

### DIFF
--- a/src/sbcl.lisp
+++ b/src/sbcl.lisp
@@ -11,10 +11,11 @@
     (warn "No environment control in SBCL on Windows.")
     (remf rest :environment))
   #-windows
-  (let ((env (reformat-environment environment)))
+  (let ((env (mapcar (lambda (var) (format nil "~a=~a" (car var) (cdr var)))
+                     environment)))
     (setf (getf rest :environment)
           (if replace-environment-p
-              (append env '("PATH=''"))
+              (append env '("PATH="))
               (append env (sb-ext:posix-environ)))))
   (remf rest :replace-environment-p)
   rest)


### PR DESCRIPTION
The old code adds simple quotes around environment values
when passing a custom environment to an external program
in SBCL.  This is wrong, because it does not pass the
intended value of the environment variables.

It seems other parts of the code base rely uses the
Bourne Shell to start external programs, which could
actually have required a quoting of some kind, so
I guess there had been confusion between the two
situations at some point.